### PR TITLE
fix: rename opencode-secret-protect to opencode-secrets-protect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# opencode-secret-protect
+# opencode-secrets-protect
 
 > **Warning**
 > This project is in **alpha** and has not been extensively tested in real-world environments. Use at your own risk and please report any issues you encounter.
@@ -41,7 +41,7 @@ Add to your `opencode.json`:
 
 ```json
 {
-  "plugin": ["opencode-secret-protect"]
+  "plugin": ["opencode-secrets-protect"]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "opencode-secret-protect",
+  "name": "opencode-secrets-protect",
   "version": "0.1.0",
   "description": "OpenCode plugin to protect against secret leakage in AI tool calls",
   "module": "src/index.ts",
@@ -9,12 +9,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jscheel/opencode-secret-protect.git"
+    "url": "git+https://github.com/jscheel/opencode-secrets-protect.git"
   },
   "bugs": {
-    "url": "https://github.com/jscheel/opencode-secret-protect/issues"
+    "url": "https://github.com/jscheel/opencode-secrets-protect/issues"
   },
-  "homepage": "https://github.com/jscheel/opencode-secret-protect#readme",
+  "homepage": "https://github.com/jscheel/opencode-secrets-protect#readme",
   "scripts": {
     "dev": "bun run --watch src/index.ts",
     "test": "bun test",


### PR DESCRIPTION
## Summary
This PR renames the package from `opencode-secret-protect` to `opencode-secrets-protect` to match the repository name.

## Changes
- Updated `package.json` name from `opencode-secret-protect` to `opencode-secrets-protect`
- Updated all GitHub URLs in `package.json` to use `opencode-secrets-protect`
- Updated `README.md` title and plugin example to use `opencode-secrets-protect`

## Motivation
The repository is named `opencode-secrets-protect` (with an 's') but the codebase was using `opencode-secret-protect` (without 's'). This inconsistency could cause confusion and issues with package discovery.